### PR TITLE
Read from JSON config in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # Available configuration variables and their defaults
 #
 
-# TODO: how to read those variables from configs/cosr-ops.prod.json ?
-COSR_AWS_STACKNAME	?= mystackname
-COSR_AWS_REGION		?= us-east-1
+COSR_AWS_STACKNAME      := $(shell python aws/config.py AWS_STACKNAME)
+COSR_AWS_REGION         := $(shell python aws/config.py AWS_REGION)
+
 
 # Path to your local install of Spark
 SPARK_DIR			?= ../spark-1.6.0

--- a/aws/config.py
+++ b/aws/config.py
@@ -1,5 +1,17 @@
 import json
+import sys
 
 
 with open("configs/cosr-ops.prod.json") as f:
-	CONFIG = json.load(f)
+    CONFIG = json.load(f)
+
+
+if __name__ == '__main__':
+    try:
+        ret_val = CONFIG.get(sys.argv[1])
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except:
+        ret_val = ''
+
+    sys.stdout.write("%s\n" % ret_val)


### PR DESCRIPTION
Addresses #7 
The existing config module (config.py) is extended to print out JSON value given the attribute.
The same module is used as a standalone program from the Makefile.
